### PR TITLE
Deprecation Warning for Rails 2.3.9

### DIFF
--- a/lib/metric_fu.rb
+++ b/lib/metric_fu.rb
@@ -1,9 +1,9 @@
 require 'rake'
 require 'yaml'
 begin
-  require 'activesupport'
-rescue LoadError
   require 'active_support'
+rescue LoadError  
+  require 'activesupport'
 end
 
 # Load a few things to make our lives easier elsewhere.


### PR DESCRIPTION
Removed deprecation warnings for Rails version 2.3.9.

i0rek
