### PR TITLE
Fix for #44 and #45

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,6 +1,8 @@
 === MetricFu 2.0.2 / ???
 
-* Flog gemspec version was >= 2.2.0, which was too early and didn't work. Changed too >= 2.3.0 -  Chris Griego
+* Flog gemspec version was >= 2.2.0, which was too early and didn't work. Changed to >= 2.3.0 -  Chris Griego
+* RCov generator now uses a regex with begin and end line anchor to avoid splitting on comments with equal signs in source files - Andrew Selder
+* RCov generator now always strips the 3 leading characters from the lines when reconstruction source files so that heredocs and block comments parse successfully - Andrew Selder
 
 === MetricFu 2.0.1 / 2010-11-13
 

--- a/lib/generators/rcov.rb
+++ b/lib/generators/rcov.rb
@@ -100,11 +100,7 @@ module MetricFu
       files.each_pair {|fname, content| files[fname] = content.split("\n") }
       files.each_pair do |fname, content|
         content.map! do |raw_line|
-          if raw_line.match(/^!!/)
-            line = Line.new(raw_line.gsub('!!', '  '), false).to_h
-          else
-            line = Line.new(raw_line, true).to_h
-          end
+          line = Line.new(raw_line[3..-1], !raw_line.match(/^!!/)).to_h
         end
         content.reject! {|line| line[:content].blank? }
         files[fname] = {:lines => content}

--- a/lib/generators/rcov.rb
+++ b/lib/generators/rcov.rb
@@ -3,7 +3,7 @@ require 'enumerator'
 module MetricFu
 
   class Rcov < Generator
-    NEW_FILE_MARKER =  ("=" * 80) + "\n"
+    NEW_FILE_MARKER = /^={80}$/.freeze
 
     class Line
       attr_accessor :content, :was_run

--- a/spec/generators/rcov_spec.rb
+++ b/spec/generators/rcov_spec.rb
@@ -47,12 +47,12 @@ describe MetricFu::Rcov do
 
       it "should know which lines were run" do
         @files["lib/templates/awesome/awesome_template.rb"][:lines].
-              should include({:content=>"   require 'fileutils'", :was_run=>true})
+              should include({:content=>"require 'fileutils'", :was_run=>true})
       end
 
       it "should know which lines NOT were run" do
         @files["lib/templates/awesome/awesome_template.rb"][:lines].
-              should include({:content=>"         if template_exists?(section)", :was_run=>false})
+              should include({:content=>"      if template_exists?(section)", :was_run=>false})
       end
     end
 


### PR DESCRIPTION
Hey Jake,

This is a couple of simple fixes to #44 and #45
1. The fix for #45 is simply using a regex with begin and end line anchors to split the rcov output. The avoid splitting on lines with 80 equals in the source files.
2. The fix for #44 is simply always stripping the 3 leading characters when recombining the files. This ensures that heredocs and block comments don't blowup.

Thanks,

Andrew
