### PR TITLE
Add configurable file prefix instead of just file:// and txmt://

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,6 +1,7 @@
 === MetricFu 2.0.2 / ???
 
 * Flog gemspec version was >= 2.2.0, which was too early and didn't work. Changed too >= 2.3.0 -  Chris Griego
+* Added link_prefix to configuration to allow URIs specified in config instead of file or txmt - dan sinclair
 
 === MetricFu 2.0.1 / 2010-11-13
 

--- a/lib/base/base_template.rb
+++ b/lib/base/base_template.rb
@@ -137,7 +137,10 @@ module MetricFu
     def file_url(name, line) # :nodoc:
       return '' unless name
       filename = File.expand_path(name.gsub(/^\//, ''))
-      if MetricFu.configuration.platform.include?('darwin')
+      link_prefix = MetricFu.configuration.link_prefix
+      if link_prefix
+        "#{link_prefix}/#{name.gsub(/:.*$/, '')}"
+      elsif MetricFu.configuration.platform.include?('darwin')
         "txmt://open/?url=file://#{filename}" << (line ? "&line=#{line}" : "")
       else
        "file://#{filename}"

--- a/lib/base/configuration.rb
+++ b/lib/base/configuration.rb
@@ -145,6 +145,8 @@ module MetricFu
       @hotspots = {}
       @file_globs_to_ignore = []
 
+      @link_prefix = nil
+
       @graph_engine = :bluff # can be :bluff or :gchart
     end
 

--- a/spec/base/base_template_spec.rb
+++ b/spec/base/base_template_spec.rb
@@ -88,6 +88,7 @@ describe MetricFu::Template do
       before(:each) do
         config = mock("configuration")
         config.stub!(:platform).and_return('universal-darwin-9.0')
+        config.stub!(:link_prefix).and_return(nil)
         MetricFu.stub!(:configuration).and_return(config)
       end
 
@@ -126,6 +127,7 @@ describe MetricFu::Template do
       before(:each) do
         config = mock("configuration")
         config.should_receive(:platform).and_return('other')
+        config.stub!(:link_prefix).and_return(nil)
         MetricFu.stub!(:configuration).and_return(config)
         File.should_receive(:expand_path).and_return('filename')
       end
@@ -134,6 +136,21 @@ describe MetricFu::Template do
         name = "filename"
         result = @template.send(:link_to_filename, name)
         result.should == "<a href='file://filename'>filename</a>"
+      end
+    end
+
+    describe "when configured with a link_prefix" do
+      before(:each) do
+        config = mock("configuration")
+        config.should_receive(:link_prefix).and_return('http://example.org/files')
+        MetricFu.stub!(:configuration).and_return(config)
+        File.should_receive(:expand_path).and_return('filename')
+      end
+
+      it 'should return a http protocol link' do
+        name = "filename"
+        result = @template.send(:link_to_filename, name)
+        result.should == "<a href='http://example.org/files/filename'>filename</a>"
       end
     end
   end


### PR DESCRIPTION
I'm setup my build box to run metric_fu but none of the file link paths work correctly as they're all generated as file://.

This patch adds a configuration flag link_prefix that I can set to something like http://example.org/files and the links will then become something like http://example.org/files/app/controllers/application_controller.rb instead of file:///users/dj2/foo/app/controllers/application_controller.rb.
