### PR TITLE
Simple verbose flag to output analyzer being executed.

### DIFF
--- a/lib/base/configuration.rb
+++ b/lib/base/configuration.rb
@@ -145,6 +145,8 @@ module MetricFu
       @hotspots = {}
       @file_globs_to_ignore = []
 
+      @verbose = false
+
       @graph_engine = :bluff # can be :bluff or :gchart
     end
 

--- a/lib/base/generator.rb
+++ b/lib/base/generator.rb
@@ -121,6 +121,10 @@ module MetricFu
     # methods to allow extra hooks into the processing methods, and help
     # to keep the logic of your Generators clean.
     def generate_report
+      if MetricFu.configuration.verbose
+        puts "Executing #{self.class.to_s.gsub(/.*::/, '')}"
+      end
+
       %w[emit analyze].each do |meth|
         send("before_#{meth}".to_sym)
         send("#{meth}".to_sym)


### PR DESCRIPTION
When metric_fu is running I'm seeing output in the console along the lines of:

  skipping app/views/foo/index.html.erb
  parse error on value ";" (tSEMI)

but, currently, have no idea which tool is generating the errors. This patch adds a simple config.verbose that will cause the name of the generator to be output as the analyzer is run.
