### PR TITLE
Stats generator was crashing if 'rake stats' outputted any blank lines

### DIFF
--- a/lib/generators/stats.rb
+++ b/lib/generators/stats.rb
@@ -26,8 +26,7 @@ module MetricFu
 
     def remove_noise(output)
       lines = output.split("\n")
-      lines = lines.find_all {|line| line[0].chr != "+" }
-      lines = lines.find_all {|line| line[0].chr != "(" }
+      lines.reject! { |line| line.empty? || ['+', '('].include?(line[0].chr) }
       lines.shift
       lines
     end

--- a/spec/generators/stats_spec.rb
+++ b/spec/generators/stats_spec.rb
@@ -13,7 +13,17 @@ describe Stats do
 
   describe "analyze method" do
     before :each do
-      @lines =  <<-HERE.gsub(/^\s*/, "")
+      @lines =  <<-HERE
+      The 'run' provides a unified access point for all the default Rails' commands.
+
+      Usage: ./script/run <command> [OPTIONS]
+
+      Examples:
+        ./script/run generate controller Admin
+        ./script/run process reaper
+
+      Choose: about, console, dbconsole, destroy, generate, plugin, runner, server, update
+
       +----------------------+-------+-------+---------+---------+-----+-------+
       | Name                 | Lines |   LOC | Classes | Methods | M/C | LOC/M |
       +----------------------+-------+-------+---------+---------+-----+-------+


### PR DESCRIPTION
Fixed the stats generator to not crash when blank lines appear in the output of 'rake stats'. One reason this occurs is if there are deprecation warnings.
