### PR TITLE
Fix deprecation warnings with ActiveSupport ~> 2.3.5

### DIFF
--- a/lib/metric_fu.rb
+++ b/lib/metric_fu.rb
@@ -1,11 +1,12 @@
 require 'rake'
 require 'yaml'
 begin
+  require 'active_support'
   require 'active_support/core_ext/object/to_json'
   require 'active_support/core_ext/object/blank'
   require 'active_support/inflector'
 rescue LoadError
-  require 'activesupport'
+  require 'activesupport' unless defined?(ActiveSupport)
 end
 
 # Load a few things to make our lives easier elsewhere.


### PR DESCRIPTION
I've gotten tired of this message in my console. :)

```
DEPRECATION WARNING: require "activesupport" is deprecated and will be removed in Rails 3. Use require "active_support" instead. (called from /vendor/bundle/ruby/1.8/gems/activesupport-2.3.11/lib/activesupport.rb:2)
```

I chose this approach instead of a nested begin/rescue block so that people using versions before 2.3.5 didn't have to suffer the overhead of two exception backtraces being generated. I tested with the first and last patch versions of each minor version of ActiveSupport between 2.0.0 and 3.0.5
