### PR TITLE
added .rvmrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tmp/*
 *.html_complexity.*
 scratch_directory/
 Gemfile.lock
+.rvmrc

--- a/.rvmrc
+++ b/.rvmrc
@@ -1,2 +1,0 @@
-rvm_gemset_create_on_use_flag=1
-rvm gemset use metric_fu


### PR DESCRIPTION
many people that cloned metric_fu should be using rvm, .rvmrc is kinda personal to be pushed to the project.

do you think the same? ;)

some discussion about this in another project: https://github.com/rails/rails/pull/194
