### PR TITLE
removed inconsistent hash accessor

### DIFF
--- a/lib/base/location.rb
+++ b/lib/base/location.rb
@@ -31,7 +31,7 @@ module MetricFu
 
     # TODO - we need this method (and hash accessor above) as a temporary hack where we're using Location as a hash key
     def eql?(other)
-      [self.file_path.to_s, self.class_name.to_s, self.method_name.to_s] == [other.file_path.to_s, other.class_name.to_s, other.method_name.to_s]
+      @hash == other.hash
     end
     # END we need these methods as a temporary hack where we're using Location as a hash key
 

--- a/spec/base/location_spec.rb
+++ b/spec/base/location_spec.rb
@@ -94,5 +94,33 @@ describe MetricFu::Location do
     end
 
   end
+  context "testing equality" do
+    before :each do
 
+      @location1 = MetricFu::Location.get('/some/path','some_class','some_method')
+
+      # ensure that we get a new object
+      @location2 = MetricFu::Location.new('/some/path','some_class','some_method')
+    end
+    it "should match two locations with the same paths as equal" do
+
+      hsh1 = {}
+      hsh1[@location1] = 1
+
+      hsh2 = {}
+      hsh2[@location2] = 1
+
+      hsh1.should == hsh2
+      hsh1.eql?(hsh2).should be_true
+
+      @location1.eql?(@location2).should be_true
+    end
+
+
+    it "should produce the same hash value given the same paths" do
+
+      @location1.hash.should == @location2.hash
+    end
+
+  end
 end


### PR DESCRIPTION
The #hash algorithm in Ruby is not consistent across Rubies. This causes a problem when running the specs (specifically hotspots_spec.rb) 
I have added some specs that test the equality function of MetricFu::Location without using actual hash values to ensure that I don't break anything.
