### PR TITLE
Remove hardcoded base dir for data dir

### DIFF
--- a/lib/base/configuration.rb
+++ b/lib/base/configuration.rb
@@ -103,7 +103,7 @@ module MetricFu
       @base_directory = ENV['CC_BUILD_ARTIFACTS'] || 'tmp/metric_fu'
       @scratch_directory = File.join(@base_directory, 'scratch')
       @output_directory = File.join(@base_directory, 'output')
-      @data_directory = File.join('tmp/metric_fu', '_data')
+      @data_directory = File.join(@base_directory, '_data')
       @metric_fu_root_directory = File.join(File.dirname(__FILE__),
                                                         '..', '..')
       @template_directory =  File.join(@metric_fu_root_directory,


### PR DESCRIPTION
Replace hardcoded path `tmp/metric_fu` with `@base_directory` for data directory.
