### PR TITLE
Psych as the default YAML parser

### DIFF
--- a/lib/metric_fu.rb
+++ b/lib/metric_fu.rb
@@ -1,5 +1,6 @@
 require 'rake'
 require 'yaml'
+YAML::ENGINE.yamler = 'psych'
 begin
   require 'active_support/core_ext/object/to_json'
   require 'active_support/core_ext/object/blank'


### PR DESCRIPTION
Make psych the default YAML parser.

I'm getting some errors currently using metric_fu and it outputs an error on the YAML file. Syck is old and should not be used anymore.
