### PR TITLE
Move chronic dependency to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,2 @@
 source "http://rubygems.org"
-gem 'rake'
-gem 'chronic', "~> 0.3.0"
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "http://rubygems.org"
 gem 'rake'
+gem 'chronic', "~> 0.3.0"
 gemspec

--- a/metric_fu.gemspec
+++ b/metric_fu.gemspec
@@ -25,6 +25,8 @@ Gem::Specification.new do |s|
   s.add_dependency("activesupport", [">= 2.0.0"])
   s.add_dependency("syntax")
 
+  s.add_development_dependency("rake")
+  s.add_dependency("chronic", ["~> 0.3.0"])
   s.add_development_dependency("rspec", ["= 1.3.0"])
   s.add_development_dependency("test-construct", [">= 1.2.0"])
   s.add_development_dependency("googlecharts")

--- a/metric_fu.gemspec
+++ b/metric_fu.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.add_dependency("reek", [">=1.2.6"])
   s.add_dependency("roodi", [">=2.1.0"])
   s.add_dependency("rails_best_practices", [">=0.6.4"])
-  s.add_dependency("chronic", ["~> 0.3.0"])
   s.add_dependency("churn", [">= 0.0.7"])
   s.add_dependency("Saikuro", [">= 1.1.0"])
   s.add_dependency("activesupport", [">= 2.0.0"])

--- a/metric_fu.gemspec
+++ b/metric_fu.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency("syntax")
 
   s.add_development_dependency("rake")
-  s.add_dependency("chronic", ["~> 0.3.0"])
+  s.add_development_dependency("chronic", ["~> 0.3.0"])
   s.add_development_dependency("rspec", ["= 1.3.0"])
   s.add_development_dependency("test-construct", [">= 1.2.0"])
   s.add_development_dependency("googlecharts")


### PR DESCRIPTION
it looks like chronic is only used for development/testing, so remove gemspec dependency so it doesn't mess with downstream apps

Signed-off-by: Joel Nimety jnimety@continuity.net
