### PR TITLE
Solve Syck:Emitter NoMethodError 

### DIFF
--- a/lib/metric_fu.rb
+++ b/lib/metric_fu.rb
@@ -1,4 +1,5 @@
 require 'rake'
+require 'psych'
 require 'yaml'
 begin
   require 'active_support/core_ext/object/to_json'


### PR DESCRIPTION
In Rails 3.1, metric-fu fails to run (via metrical) due to the following error:

`/Users/rambo/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/1.9.1/psych/visitors/emitter.rb:17:in`end_document': undefined method `write' for #<Syck::Emitter:0x007fcc4120b498> (NoMethodError)`

Including `require psych` solves this problem.
